### PR TITLE
Older phoenix version syntax

### DIFF
--- a/manuscript/diving_in.md
+++ b/manuscript/diving_in.md
@@ -284,7 +284,7 @@ end
 And we're going to update it with our new players resource:
 
 ```elixir
-scope "/", Platform.Web do
+scope "/", PlatformWeb do
   pipe_through :browser # Use the default browser stack
 
   get "/", PageController, :index


### PR DESCRIPTION
This syntax was used before the 1.3 version of Phoenix framework according to the part 7 of the [migration guide](https://gist.github.com/chrismccord/71ab10d433c98b714b75c886eff17357)